### PR TITLE
feat: add AWS cloud deploy version for data collector as Lambda

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 plotly
 pandas
 flask
+boto3


### PR DESCRIPTION
Removes keeping the data collector as a long lived process so that it can be used as a Lambda when deploying to AWS Cloud. This assumes that the `GITHUB_TOKEN` is stored in a proper place i.e. AWS Secrets Manager from where it gets fetched via `boto3` on startup.